### PR TITLE
Backport fix for HelpController#catch_spam method

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -16,3 +16,24 @@
 #         end
 #     end
 # end
+
+Rails.configuration.to_prepare do
+
+  HelpController.class_eval do
+
+    private
+
+    # Backported fix from release/0.25.0.0 - prevents error when
+    # params[:contact] is missing or empty
+    # https://github.com/mysociety/alaveteli/commit/d62498d26fe3250665ba0751e680b0c843adf65f
+    def catch_spam
+      if request.post? && params[:contact]
+        if !params[:contact][:comment].blank? || !params[:contact].key?(:comment)
+          redirect_to frontpage_url
+        end
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Before Alaveteli version 0.25.0.0, the `catch_spam` method in the help
controller can cause site errors if the contact field is not filled in.

Original fix here
https://github.com/mysociety/alaveteli/commit/d62498d26fe3250665ba0751e680b0c843adf65f

(Tested locally - adding the theme code prevents an error when posting random data to the form)

Fixes #90

### Note for reviewer/future readers

`bundle update debugger-ruby_core_source` may be required to install gems for a `0.22.4.9`site  under the latest Ruby 1.9.3 (just found out the hard way) 